### PR TITLE
fix: don't send confirmation on /spam

### DIFF
--- a/src/team_bot/relay.py
+++ b/src/team_bot/relay.py
@@ -145,7 +145,8 @@ def handle_msg_in_relay_group(msg: AttrDict):
             reply(msg.chat, relay_group_help(), quote=msg.message)
         if arguments[0] == "/spam" or arguments[0] == "/mute":
             if mute_relay_group(msg.chat):
-                reply(msg.chat, "Ignoring chat in the future.", quote=msg.message)
+                if arguments[0] != "/spam":  # workaround for some other automation
+                    reply(msg.chat, "Ignoring chat in the future.", quote=msg.message)
             else:
                 reply(msg.chat, "Chat is already muted.", quote=msg.message)
         if arguments[0] == "/unmute":


### PR DESCRIPTION
One instance has a bot which runs on the users' profiles, and deletes any chat where members post `/spam`. In such a case, the success message leads to the chat re-appearing. This PR avoids that.