### PR TITLE
feat: use /timer in a relay group to set disappearing messages for the outside chat

### DIFF
--- a/src/team_bot/commands.py
+++ b/src/team_bot/commands.py
@@ -8,7 +8,14 @@ from deltachat_rpc_client._utils import AttrDict
 from deltachat_rpc_client.rpc import JsonRpcError
 
 from .forwarding import forward_to_relay_group
-from .util import get_outside_chat, get_prefix, get_relay_groups, parse_new_command_args, set_relay_groups
+from .util import (
+    get_outside_chat,
+    get_prefix,
+    get_relay_groups,
+    parse_duration,
+    parse_new_command_args,
+    set_relay_groups,
+)
 
 log = logging.getLogger("root")
 
@@ -77,6 +84,7 @@ Change the help message for outsiders:\t/set_outside_help Hello outsider
 def relay_group_help():
     """Get the help message for relay groups"""
     help_text = """
+Disappearing messages:\t/timer 7d
 Ignore future messages:\t/mute
 Get messages again:\t\t/unmute
 Show this help text:\t\t/help
@@ -93,6 +101,25 @@ def set_outside_help(account: Account, help_message: str):
     """Set the help message for outsiders"""
     logging.info("Setting outside_help_message to %s", help_message)
     account.set_config("ui.outside_help_message", help_message)
+
+
+def set_ephemeral_timer(relay_group: Chat, human_readable: str) -> str:
+    """In the outside chat to this relay group, set an ephemeral timer.
+
+    :param relay_group: the relay group in which the command was sent
+    :param human_readable: the human-readable duration, e.g. 7d, 3w, 30m, 10s.
+    :return: a success/failure message to reply to the chat.
+    """
+    try:
+        timer_seconds = parse_duration(human_readable)
+    except ValueError:
+        return f"{human_readable} is not a valid duration, try 7d, 4w, or 30m."
+    outside_chat = get_outside_chat(relay_group)
+    result = "disabled" if human_readable == "0" else human_readable
+    if outside_chat.get_full_snapshot().ephemeral_timer == timer_seconds:
+        return f"The disappearing messages timer is already {result}."
+    outside_chat.set_ephemeral_timer(timer_seconds)
+    return f"Disappearing messages timer is now {result}."
 
 
 def mute_relay_group(relay_group: Chat) -> bool:

--- a/src/team_bot/relay.py
+++ b/src/team_bot/relay.py
@@ -13,6 +13,7 @@ from .commands import (
     resend_missed_messages,
     set_avatar,
     set_display_name,
+    set_ephemeral_timer,
     set_outside_help,
     set_prefix,
     start_chat,
@@ -143,6 +144,13 @@ def handle_msg_in_relay_group(msg: AttrDict):
         arguments = msg.text.split()
         if arguments[0] == "/help":
             reply(msg.chat, relay_group_help(), quote=msg.message)
+        if arguments[0] == "/timer":
+            if len(arguments) < 2:
+                human_readable_duration = "0"
+            else:
+                human_readable_duration = arguments[1]
+            result = set_ephemeral_timer(msg.chat, human_readable_duration)
+            reply(msg.chat, result, quote=msg.message)
         if arguments[0] == "/spam" or arguments[0] == "/mute":
             if mute_relay_group(msg.chat):
                 reply(msg.chat, "Ignoring chat in the future.", quote=msg.message)

--- a/src/team_bot/util.py
+++ b/src/team_bot/util.py
@@ -71,6 +71,30 @@ def get_prefix(account: Account) -> str:
     return prefix
 
 
+def parse_duration(human_readable: str) -> int:
+    """Parse a human readable duration.
+
+    :param: human_readable: the duration with a unit: e.g. 7d, 3w, 30m, 10s
+    :return: how many seconds the duration lasts.
+    """
+    match human_readable[-1]:
+        case "w":
+            seconds = int(human_readable.rstrip("w")) * 60 * 60 * 24 * 7
+        case "d":
+            seconds = int(human_readable.rstrip("d")) * 60 * 60 * 24
+        case "h":
+            seconds = int(human_readable.rstrip("h")) * 60 * 60
+        case "m":
+            seconds = int(human_readable.rstrip("m")) * 60
+        case "s":
+            seconds = int(human_readable.rstrip("s"))
+        case _:
+            seconds = int(human_readable)
+    if seconds < 0:
+        raise ValueError
+    return seconds
+
+
 def parse_new_command_args(command_text: str) -> ([str], str, str):
     """Parse a /new_command message to get recipients, title, and text out of it.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,3 +53,29 @@ def outsider(acfactory, log):
     outsider = acfactory.get_online_account()
     outsider.set_config("displayname", "Outsider for TEST team")
     return outsider
+
+
+def join_chat(user, invite, log):
+    user.secure_join(invite)
+    user.wait_for_securejoin_joiner_success()
+    log.step("Joiner receives member_added message")
+    [print(chat.get_full_snapshot().name) for chat in user.get_chatlist()]
+    return user.get_chatlist()[0]
+
+
+@pytest.fixture
+def relay_group(crew, bot, outsider, crew_member, log):
+    log.step("send message to bot")
+    bot_invite = bot.account.get_qr_code()
+    outsider_outside_chat = join_chat(outsider, bot_invite, log)
+    outsider_outside_chat.send_text("test 1:1 message to bot")
+
+    log.step("bot creates relay group")
+    bot._process_events(until_event=EventType.INCOMING_MSG)
+
+    log.step("get relay group")
+    group_explanation_message = crew_member.wait_for_incoming_msg().get_snapshot()
+    assert "This is a chat with Outsider for TEST team" in group_explanation_message.text
+    user_forwarded_message_from_outsider = crew_member.wait_for_incoming_msg().get_snapshot()
+    assert user_forwarded_message_from_outsider.text == "test 1:1 message to bot"
+    return user_forwarded_message_from_outsider.chat

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -92,6 +92,42 @@ def test_not_relay_groups(crew, bot, crew_member, outsider, log):
     assert not is_relay_group(bot_message_from_user.chat)
 
 
+def test_relay_timer(relay_group, bot, crew_member, outsider, log):
+    log.step("Timer is off, send /timer")
+    relay_group.send_text("/timer")
+    bot._process_events(until_event=EventType.INCOMING_MSG)
+    bot_reply = crew_member.wait_for_incoming_msg().get_snapshot()
+    assert bot_reply.text == "The disappearing messages timer is already disabled."
+
+    log.step("Timer is off, send /timer 10s")
+    relay_group.send_text("/timer 10s")
+    bot._process_events(until_event=EventType.INCOMING_MSG)
+    bot_reply = crew_member.wait_for_incoming_msg().get_snapshot()
+    assert bot_reply.text == "Disappearing messages timer is now 10s."
+
+    log.step("Check that outsider has 10 seconds, too")
+    timer_10s = outsider.wait_for_incoming_msg().get_snapshot()
+    assert timer_10s.text == "Message deletion timer is set to 10 s by Bot from TEST team."
+    assert timer_10s.chat.get_full_snapshot().ephemeral_timer == 10
+
+    log.step("Timer is 10s, send /timer 10s")
+    relay_group.send_text("/timer 10s")
+    bot._process_events(until_event=EventType.INCOMING_MSG)
+    bot_reply = crew_member.wait_for_incoming_msg().get_snapshot()
+    assert bot_reply.text == "The disappearing messages timer is already 10s."
+
+    log.step("Timer is 10s, send /timer 0")
+    relay_group.send_text("/timer 0")
+    bot._process_events(until_event=EventType.INCOMING_MSG)
+    bot_reply = crew_member.wait_for_incoming_msg().get_snapshot()
+    assert bot_reply.text == "Disappearing messages timer is now disabled."
+
+    log.step("Check that outsider sees disabled, too")
+    timer_disabled = outsider.wait_for_incoming_msg().get_snapshot()
+    assert timer_disabled.text == "Message deletion timer is disabled by Bot from TEST team."
+    assert timer_disabled.chat.get_full_snapshot().ephemeral_timer == 0
+
+
 @pytest.mark.timeout(TIMEOUT)
 def test_relay_outside_1on1_chats(crew, bot, crew_member, outsider, log):
     log.step("send message to bot")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,28 @@
+import pytest
+
+from team_bot.util import parse_duration
+
+
+@pytest.mark.parametrize(
+    ("human_readable", "seconds"),
+    [
+        ("3w", 3 * 7 * 24 * 60 * 60),
+        ("6dd", 6 * 24 * 60 * 60),
+        ("6d", 6 * 24 * 60 * 60),
+        ("20h", 20 * 60 * 60),
+        ("33m", 33 * 60),
+        ("20s", 20),
+        ("20", 20),
+        ("-12m", -999),
+        ("23dm", -999),
+        ("three", -999),
+        ("78z", -999),
+        ("-66", -999),
+    ],
+)
+def test_parse_duration(human_readable, seconds):
+    if seconds == -999:
+        with pytest.raises(ValueError):
+            parse_duration(human_readable)
+    else:
+        assert parse_duration(human_readable) == seconds


### PR DESCRIPTION
one of the features proposed in #8 