### PR TITLE
fix: git autostash config needs to be applied to unix_user

### DIFF
--- a/src/team_bot/pyinfra.py
+++ b/src/team_bot/pyinfra.py
@@ -25,6 +25,8 @@ def deploy_team_bot(
     git.config(
         key="rebase.autoStash",
         value="true",
+        _su_user=unix_user,
+        _use_su_login=True,
     )
     clone_repo = git.repo(
         name="Pull the team-bot repository",


### PR DESCRIPTION
Currently:
- local changes in the git repository still cause an error
- root's git config is changed for no reason, the config change should be contained in the unix_user.