### PR TITLE
fix: detecting group creation message

### DIFF
--- a/src/team_bot/util.py
+++ b/src/team_bot/util.py
@@ -66,10 +66,10 @@ def get_outside_chat(relay_group: Chat) -> Chat:
 
 def get_group_creation_msg(relay_group: Chat) -> Optional[Message | None]:
     """For a relay group, return the snapshot of the group creation message."""
-    beginnings = ["This is a chat with ", "We sent a message to", "This is the relay gr"]
+    beginnings = ["This is a chat with ", "We sent a message to ", "This is the relay group for "]
     if is_relay_group(relay_group):
         for msg in relay_group.get_messages()[:2]:
-            if msg.get_snapshot().text[:20] in beginnings:
+            if any([msg.get_snapshot().text.startswith(beginning) for beginning in beginnings]):
                 return msg
 
 

--- a/src/team_bot/util.py
+++ b/src/team_bot/util.py
@@ -66,14 +66,11 @@ def get_outside_chat(relay_group: Chat) -> Chat:
 
 def get_group_creation_msg(relay_group: Chat) -> Optional[Message | None]:
     """For a relay group, return the snapshot of the group creation message."""
+    beginnings = ["This is a chat with ", "We sent a message to", "This is the relay gr"]
     if is_relay_group(relay_group):
-        msgs = relay_group.get_messages()
-        assert msgs[1].get_snapshot().text[:20] in [
-            "This is a chat with ",
-            "We sent a message to",
-            "This is the relay gr",
-        ]
-        return msgs[1]
+        for msg in relay_group.get_messages():
+            if msg.get_snapshot().text[:20] in beginnings:
+                return msg
 
 
 def get_prefix(account: Account) -> str:

--- a/src/team_bot/util.py
+++ b/src/team_bot/util.py
@@ -68,7 +68,7 @@ def get_group_creation_msg(relay_group: Chat) -> Optional[Message | None]:
     """For a relay group, return the snapshot of the group creation message."""
     beginnings = ["This is a chat with ", "We sent a message to", "This is the relay gr"]
     if is_relay_group(relay_group):
-        for msg in relay_group.get_messages():
+        for msg in relay_group.get_messages()[:2]:
             if msg.get_snapshot().text[:20] in beginnings:
                 return msg
 

--- a/src/team_bot/util.py
+++ b/src/team_bot/util.py
@@ -68,7 +68,11 @@ def get_group_creation_msg(relay_group: Chat) -> Optional[Message | None]:
     """For a relay group, return the snapshot of the group creation message."""
     if is_relay_group(relay_group):
         msgs = relay_group.get_messages()
-        assert msgs[1].get_snapshot().text[:20] in ["This is a chat with ", "We sent a message to"]
+        assert msgs[1].get_snapshot().text[:20] in [
+            "This is a chat with ",
+            "We sent a message to",
+            "This is the relay gr",
+        ]
         return msgs[1]
 
 

--- a/src/team_bot/util.py
+++ b/src/team_bot/util.py
@@ -66,10 +66,10 @@ def get_outside_chat(relay_group: Chat) -> Chat:
 
 def get_group_creation_msg(relay_group: Chat) -> Optional[Message | None]:
     """For a relay group, return the snapshot of the group creation message."""
-    beginnings = ["This is a chat with ", "We sent a message to ", "This is the relay group for "]
+    beginnings = ("This is a chat with ", "We sent a message to ", "This is the relay group for ")
     if is_relay_group(relay_group):
-        for msg in relay_group.get_messages()[:2]:
-            if any([msg.get_snapshot().text.startswith(beginning) for beginning in beginnings]):
+        for msg in relay_group.get_messages()[:3]:
+            if msg.get_snapshot().text.startswith(beginnings):
                 return msg
 
 

--- a/src/team_bot/util.py
+++ b/src/team_bot/util.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import re
-from typing import Optional
 
 from deltachat_rpc_client import Account, Chat, Message
 from deltachat_rpc_client._utils import AttrDict
@@ -9,12 +8,12 @@ from deltachat_rpc_client._utils import AttrDict
 log = logging.getLogger("root")
 
 
-def has_crew(event: AttrDict) -> Optional[bool]:
+def has_crew(event: AttrDict) -> bool | None:
     account = event.account
     return bool(get_crew_id_from_account(account))
 
 
-def get_crew_id_from_account(account: Account) -> Optional[int]:
+def get_crew_id_from_account(account: Account) -> int | None:
     crew_id = account.get_config("ui.crew_id")
     if crew_id:
         return int(crew_id)
@@ -64,7 +63,7 @@ def get_outside_chat(relay_group: Chat) -> Chat:
             return relay_group.account.get_chat_by_id(mapping[0])
 
 
-def get_group_creation_msg(relay_group: Chat) -> Optional[Message | None]:
+def get_group_creation_msg(relay_group: Chat) -> Message | None:
     """For a relay group, return the snapshot of the group creation message."""
     beginnings = ("This is a chat with ", "We sent a message to ", "This is the relay group for ")
     if is_relay_group(relay_group):


### PR DESCRIPTION
Depending on the core and team-bot version when the chat was created, the group creation message can be in a different position and have different wording. Iterating through legacy wordings as well, through the first three messages, should be enough to catch it.

The current behavior leads to failing messages with the following traceback:

```
Traceback (most recent call last):                                                                   
  File "/home/das_synthikat/.local/lib/team-bot.venv/lib/python3.11/site-packages/deltachat_rpc_client/client.py", line 136, in _on_event                                  
    hook(event)                                                                       
  File "/home/das_synthikat/.local/lib/team-bot.venv/lib/python3.11/site-packages/team_bot/relay.py", line 98, in incoming_message                                         
    handle_msg_in_relay_group(msg)                                                                   
  File "/home/das_synthikat/.local/lib/team-bot.venv/lib/python3.11/site-packages/team_bot/relay.py", line 176, in handle_msg_in_relay_group                               
    forward_to_outside(msg)                                                                   
  File "/home/das_synthikat/.local/lib/team-bot.venv/lib/python3.11/site-packages/team_bot/forwarding.py", line 55, in forward_to_outside                                  
    raise e                                                                   
  File "/home/das_synthikat/.local/lib/team-bot.venv/lib/python3.11/site-packages/team_bot/forwarding.py", line 38, in forward_to_outside                                  
    if msg.quote.message_id == get_group_creation_msg(msg.chat).id:                                                                                                        
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                        
  File "/home/das_synthikat/.local/lib/team-bot.venv/lib/python3.11/site-packages/team_bot/util.py", line 71, in get_group_creation_msg                                    
    assert msgs[1].get_snapshot().text[:20] in ["This is a chat with ", "We sent a message to"]                                                                       
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError                                                                                                                                                             
```